### PR TITLE
deps: Bump cider/orchard to 0.9.2

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
                                :exclusions [org.clojure/clojure]]
                  ^:inline-dep [org.clojure/tools.namespace "1.1.0" ; required by cljfmt
                                :exclusions [org.clojure/java.classpath]]
-                 ^:inline-dep [cider/orchard "0.7.3"]
+                 ^:inline-dep [cider/orchard "0.9.2"]
                  ^:inline-dep [cljfmt "0.8.0"
                                :exclusions [org.clojure/clojure
                                             org.clojure/clojurescript


### PR DESCRIPTION
Fixes #19

~~**Untested**: I tried running `lein test`, but your test/deps setup seems to have a different way to run tests.~~

**All tests pass**:
```sh
$ lein test-all
Performing task 'test' with profile(s): '1.9'
# <snip>
Ran 45 tests containing 297 assertions.
0 failures, 0 errors.
Performing task 'test' with profile(s): '1.10'
# <snip>
Ran 45 tests containing 297 assertions.
0 failures, 0 errors.
Performing task 'test' with profile(s): '1.10.3'
# <snip>
Ran 45 tests containing 297 assertions.
0 failures, 0 errors.
```