### PR TITLE
deps: Bump medley to 1.4.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -15,7 +15,7 @@
                                :exclusions [org.clojure/clojure
                                             org.clojure/clojurescript
                                             org.clojure/tools.reader]]
-                 ^:inline-dep [medley "1.3.0"
+                 ^:inline-dep [medley "1.4.0"
                                :exclusions [org.clojure/clojure]]]
 
   :plugins [[thomasa/mranderson "0.5.3"]


### PR DESCRIPTION
Fixes #21

* The Medley update that fixes this warning landed late last night
* **All tests pass**:
   ```sh
   $ lein test-all
   Performing task 'test' with profile(s): '1.9'
   # <snip>
   Ran 45 tests containing 297 assertions.
   0 failures, 0 errors.
   Performing task 'test' with profile(s): '1.10'
   # <snip>
   Ran 45 tests containing 297 assertions.
   0 failures, 0 errors.
   Performing task 'test' with profile(s): '1.10.3'
   # <snip>
   Ran 45 tests containing 297 assertions.
   0 failures, 0 errors.
   ```